### PR TITLE
clarify iOS requirements

### DIFF
--- a/docs/EN/Getting-Started/iphone.md
+++ b/docs/EN/Getting-Started/iphone.md
@@ -1,19 +1,23 @@
 ## Compatible devices
 
-iAPS requires a relatively recent iPhone. The faster the phone, the better for the algorithm and battery life. You need a minimum version of the mobile operating software, called the phone's "iOS", to be installed on your iPhone. iAPS is compatible with iPhones running on iOS 15.1 or newer.
+iAPS requires a relatively recent iPhone. The faster the phone, the better for the algorithm and battery life. You need a minimum version of the mobile operating software, called the phone's "iOS", to be installed on your iPhone. iAPS is compatible with iPhones running on iOS 16 or newer.
 
 ### iPhone
 
-These devices are compatible with iOS 16 and newer iOS.
+These devices are compatible with iOS 17:
 
+- iPhone 15, all variants
 - iPhone 14, all variants
 - iPhone 13, all variants
 - iPhone 12, all variants
 - iPhone 11, all variants
-- iPhone X, all variants
-- iPhone 8, all variants
 - iPhone SE (3rd generation or later model; 2022 first release)
 - iPhone SE (2nd generation; 2020 first release)
+
+These devices are compatible with iOS 16, but would not be compatible if future versions of iAPS require iOS 17:
+
+- iPhone X, all variants
+- iPhone 8, all variants
 
 #### iOS version and Developer Mode
 


### PR DESCRIPTION
Update 15 to 16 as minimum iOS requirement.

Separate iOS 16 from iOS 17 compatible phones.